### PR TITLE
Prevent Redownloading and Reextracting Go Build

### DIFF
--- a/cmake/SetupGo.cmake
+++ b/cmake/SetupGo.cmake
@@ -10,38 +10,42 @@ include_guard(GLOBAL)
 #
 # This function sets the `GO_EXECUTABLE` variable to the location of the Go executable.
 function(setup_go)
-  if(CMAKE_SYSTEM_NAME STREQUAL Linux)
-    set(URL https://go.dev/dl/go1.22.2.linux-amd64.tar.gz)
-    set(EXPECTED_MD5 f64eb5791a9dab9cbcdf6549b9583280)
-  elseif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
-    set(URL https://go.dev/dl/go1.22.2.darwin-amd64.tar.gz)
-    set(EXPECTED_MD5 6a8e1186969f0ce1cc6fc2551d834c6b)
-  elseif(CMAKE_SYSTEM_NAME STREQUAL Windows)
-    set(URL https://go.dev/dl/go1.22.2.windows-amd64.zip)
-    set(EXPECTED_MD5 125813601d166b742b5ab86d986be78c)
-  else()
-    message(FATAL_ERROR "Unsupported system for setting up Go: ${CMAKE_SYSTEM_NAME}")
-  endif()
-
-  file(MAKE_DIRECTORY ${CMAKE_BUILD_DIR}/_deps)
-  get_filename_component(FILENAME ${URL} NAME)
-
-  file(
-    DOWNLOAD ${URL} ${CMAKE_BUILD_DIR}/_deps/${FILENAME}
-    EXPECTED_MD5 ${EXPECTED_MD5}
-  )
-
-  execute_process(
-    COMMAND tar -xf ${CMAKE_BUILD_DIR}/_deps/${FILENAME} -C ${CMAKE_BUILD_DIR}/_deps
-    RESULT_VARIABLE RES
-  )
-  if(NOT RES EQUAL 0)
-    message(FATAL_ERROR "Failed to extract '${CMAKE_BUILD_DIR}/_deps/${FILENAME}' to '${CMAKE_BUILD_DIR}/_deps' (${RES})")
-  endif()
-
   if(CMAKE_SYSTEM_NAME STREQUAL Windows)
-    set(GO_EXECUTABLE ${CMAKE_BUILD_DIR}/_deps/go/bin/go.exe PARENT_SCOPE)
+    set(GO_EXECUTABLE ${CMAKE_BUILD_DIR}/_deps/go/bin/go.exe)
   else()
-    set(GO_EXECUTABLE ${CMAKE_BUILD_DIR}/_deps/go/bin/go PARENT_SCOPE)
+    set(GO_EXECUTABLE ${CMAKE_BUILD_DIR}/_deps/go/bin/go)
   endif()
+
+  if(NOT EXISTS ${GO_EXECUTABLE})
+    if(CMAKE_SYSTEM_NAME STREQUAL Linux)
+      set(URL https://go.dev/dl/go1.22.2.linux-amd64.tar.gz)
+      set(EXPECTED_MD5 f64eb5791a9dab9cbcdf6549b9583280)
+    elseif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+      set(URL https://go.dev/dl/go1.22.2.darwin-amd64.tar.gz)
+      set(EXPECTED_MD5 6a8e1186969f0ce1cc6fc2551d834c6b)
+    elseif(CMAKE_SYSTEM_NAME STREQUAL Windows)
+      set(URL https://go.dev/dl/go1.22.2.windows-amd64.zip)
+      set(EXPECTED_MD5 125813601d166b742b5ab86d986be78c)
+    else()
+      message(FATAL_ERROR "Unsupported system for setting up Go: ${CMAKE_SYSTEM_NAME}")
+    endif()
+
+    file(MAKE_DIRECTORY ${CMAKE_BUILD_DIR}/_deps)
+    get_filename_component(FILENAME ${URL} NAME)
+
+    file(
+      DOWNLOAD ${URL} ${CMAKE_BUILD_DIR}/_deps/${FILENAME}
+      EXPECTED_MD5 ${EXPECTED_MD5}
+    )
+
+    execute_process(
+      COMMAND tar -xf ${CMAKE_BUILD_DIR}/_deps/${FILENAME} -C ${CMAKE_BUILD_DIR}/_deps
+      RESULT_VARIABLE RES
+    )
+    if(NOT RES EQUAL 0)
+      message(FATAL_ERROR "Failed to extract '${CMAKE_BUILD_DIR}/_deps/${FILENAME}' to '${CMAKE_BUILD_DIR}/_deps' (${RES})")
+    endif()
+  endif()
+
+  set(GO_EXECUTABLE ${GO_EXECUTABLE} PARENT_SCOPE)
 endfunction()

--- a/cmake/SetupGo.cmake
+++ b/cmake/SetupGo.cmake
@@ -33,11 +33,13 @@ function(setup_go)
     file(MAKE_DIRECTORY ${CMAKE_BUILD_DIR}/_deps)
     get_filename_component(FILENAME ${URL} NAME)
 
+    # Download the Go build.
     file(
       DOWNLOAD ${URL} ${CMAKE_BUILD_DIR}/_deps/${FILENAME}
       EXPECTED_MD5 ${EXPECTED_MD5}
     )
 
+    # Extract the Go build.
     execute_process(
       COMMAND tar -xf ${CMAKE_BUILD_DIR}/_deps/${FILENAME} -C ${CMAKE_BUILD_DIR}/_deps
       RESULT_VARIABLE RES
@@ -45,6 +47,9 @@ function(setup_go)
     if(NOT RES EQUAL 0)
       message(FATAL_ERROR "Failed to extract '${CMAKE_BUILD_DIR}/_deps/${FILENAME}' to '${CMAKE_BUILD_DIR}/_deps' (${RES})")
     endif()
+
+    # Remove the downloaded Go build to free up space.
+    file(REMOVE ${CMAKE_BUILD_DIR}/_deps/${FILENAME})
   endif()
 
   set(GO_EXECUTABLE ${GO_EXECUTABLE} PARENT_SCOPE)


### PR DESCRIPTION
This pull request resolves #12 by modifying the logic in the `setup_go` function to download and extract the Go build only if the Go executable does not exist. This change also removes the downloaded Go build after extraction to free up space.