### PR TITLE
Remove Executable Check in Testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.29)
+cmake_minimum_required(VERSION 3.19)
 
 project(
   SetupGo

--- a/test/cmake/SetupGoTest.cmake
+++ b/test/cmake/SetupGoTest.cmake
@@ -20,10 +20,6 @@ if("Set up the latest version of Go" MATCHES ${TEST_MATCHES})
     message(FATAL_ERROR "The Go executable at '${GO_EXECUTABLE}' should exist")
   endif()
 
-  if(NOT IS_EXECUTABLE ${GO_EXECUTABLE})
-    message(FATAL_ERROR "The Go executable at '${GO_EXECUTABLE}' should be executable")
-  endif()
-
   execute_process(
     COMMAND ${GO_EXECUTABLE} version
     RESULT_VARIABLE RES


### PR DESCRIPTION
This pull request resolves #16 by removing lines for checking if the `GO_EXECUTABLE` variable contains an executable in the `SetupGoTest.cmake` file. This change effectively also decrease the minimum required CMake version to 3.19.