### PR TITLE
Extract Downloaded Go Build to a Unique Directory

### DIFF
--- a/cmake/SetupGo.cmake
+++ b/cmake/SetupGo.cmake
@@ -37,8 +37,9 @@ function(setup_go)
     set(PACKAGE_EXT .tar.gz)
   endif()
 
-  set(GO_PACKAGE go${VERSION}.${OS}-${ARCH}${PACKAGE_EXT})
-  set(GO_EXECUTABLE ${CMAKE_BINARY_DIR}/_deps/go/bin/go${EXECUTABLE_EXT})
+  set(GO_BUILD go${VERSION}.${OS}-${ARCH})
+  set(GO_PACKAGE ${GO_BUILD}${PACKAGE_EXT})
+  set(GO_EXECUTABLE ${CMAKE_BINARY_DIR}/_deps/${GO_BUILD}/go/bin/go${EXECUTABLE_EXT})
 
   if(NOT EXISTS ${GO_EXECUTABLE})
     # Download the Go build.
@@ -46,12 +47,13 @@ function(setup_go)
     file(DOWNLOAD https://go.dev/dl/${GO_PACKAGE} ${CMAKE_BINARY_DIR}/_deps/${GO_PACKAGE})
 
     # Extract the Go build.
+    file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/_deps/${GO_BUILD})
     execute_process(
-      COMMAND tar -xf ${CMAKE_BINARY_DIR}/_deps/${GO_PACKAGE} -C ${CMAKE_BINARY_DIR}/_deps
+      COMMAND tar -xf ${CMAKE_BINARY_DIR}/_deps/${GO_PACKAGE} -C ${CMAKE_BINARY_DIR}/_deps/${GO_BUILD}
       RESULT_VARIABLE RES
     )
     if(NOT RES EQUAL 0)
-      message(FATAL_ERROR "Failed to extract '${CMAKE_BINARY_DIR}/_deps/${GO_PACKAGE}' to '${CMAKE_BINARY_DIR}/_deps' (${RES})")
+      message(FATAL_ERROR "Failed to extract '${CMAKE_BINARY_DIR}/_deps/${GO_PACKAGE}' to '${CMAKE_BINARY_DIR}/_deps/${GO_BUILD}' (${RES})")
     endif()
 
     # Remove the downloaded Go build to free up space.

--- a/cmake/SetupGo.cmake
+++ b/cmake/SetupGo.cmake
@@ -10,46 +10,52 @@ include_guard(GLOBAL)
 #
 # This function sets the `GO_EXECUTABLE` variable to the location of the Go executable.
 function(setup_go)
-  if(CMAKE_SYSTEM_NAME STREQUAL Windows)
-    set(GO_EXECUTABLE ${CMAKE_BINARY_DIR}/_deps/go/bin/go.exe)
+  set(VERSION 1.22.2)
+
+  if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+    set(OS darwin)
+  elseif(CMAKE_SYSTEM_NAME STREQUAL Linux)
+    set(OS linux)
+  elseif(CMAKE_SYSTEM_NAME STREQUAL Windows)
+    set(OS windows)
   else()
-    set(GO_EXECUTABLE ${CMAKE_BINARY_DIR}/_deps/go/bin/go)
+    message(FATAL_ERROR "Unsupported system for setting up Go: ${CMAKE_SYSTEM_NAME}")
   endif()
 
+  if(CMAKE_SYSTEM_PROCESSOR STREQUAL x86_64 OR CMAKE_SYSTEM_PROCESSOR STREQUAL AMD64)
+    set(ARCH amd64)
+  elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL arm64)
+    set(ARCH arm64)
+  else()
+    message(FATAL_ERROR "Unsupported architecture for setting up Go: ${CMAKE_SYSTEM_PROCESSOR}")
+  endif()
+
+  if(OS STREQUAL windows)
+    set(PACKAGE_EXT .zip)
+    set(EXECUTABLE_EXT .exe)
+  else()
+    set(PACKAGE_EXT .tar.gz)
+  endif()
+
+  set(GO_PACKAGE go${VERSION}.${OS}-${ARCH}${PACKAGE_EXT})
+  set(GO_EXECUTABLE ${CMAKE_BINARY_DIR}/_deps/go/bin/go${EXECUTABLE_EXT})
+
   if(NOT EXISTS ${GO_EXECUTABLE})
-    if(CMAKE_SYSTEM_NAME STREQUAL Linux)
-      set(URL https://go.dev/dl/go1.22.2.linux-amd64.tar.gz)
-    elseif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
-      if(CMAKE_SYSTEM_PROCESSOR STREQUAL x86_64)
-        set(URL https://go.dev/dl/go1.22.2.darwin-amd64.tar.gz)
-      elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL arm64)
-        set(URL https://go.dev/dl/go1.22.2.darwin-arm64.tar.gz)
-      else()
-        message(FATAL_ERROR "Unsupported architecture for setting up Go: ${CMAKE_SYSTEM_PROCESSOR}")
-      endif()
-    elseif(CMAKE_SYSTEM_NAME STREQUAL Windows)
-      set(URL https://go.dev/dl/go1.22.2.windows-amd64.zip)
-    else()
-      message(FATAL_ERROR "Unsupported system for setting up Go: ${CMAKE_SYSTEM_NAME}")
-    endif()
-
-    file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/_deps)
-    get_filename_component(FILENAME ${URL} NAME)
-
     # Download the Go build.
-    file(DOWNLOAD ${URL} ${CMAKE_BINARY_DIR}/_deps/${FILENAME})
+    file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/_deps)
+    file(DOWNLOAD https://go.dev/dl/${GO_PACKAGE} ${CMAKE_BINARY_DIR}/_deps/${GO_PACKAGE})
 
     # Extract the Go build.
     execute_process(
-      COMMAND tar -xf ${CMAKE_BINARY_DIR}/_deps/${FILENAME} -C ${CMAKE_BINARY_DIR}/_deps
+      COMMAND tar -xf ${CMAKE_BINARY_DIR}/_deps/${GO_PACKAGE} -C ${CMAKE_BINARY_DIR}/_deps
       RESULT_VARIABLE RES
     )
     if(NOT RES EQUAL 0)
-      message(FATAL_ERROR "Failed to extract '${CMAKE_BINARY_DIR}/_deps/${FILENAME}' to '${CMAKE_BINARY_DIR}/_deps' (${RES})")
+      message(FATAL_ERROR "Failed to extract '${CMAKE_BINARY_DIR}/_deps/${GO_PACKAGE}' to '${CMAKE_BINARY_DIR}/_deps' (${RES})")
     endif()
 
     # Remove the downloaded Go build to free up space.
-    file(REMOVE ${CMAKE_BINARY_DIR}/_deps/${FILENAME})
+    file(REMOVE ${CMAKE_BINARY_DIR}/_deps/${GO_PACKAGE})
   endif()
 
   set(GO_EXECUTABLE ${GO_EXECUTABLE} PARENT_SCOPE)


### PR DESCRIPTION
This pull request resolves #23 by modifying the downloaded Go build to be extracted according to the Tarball or Zip file name. This change also refactors how the downloaded Go package names are specified based on the Go version, OS name, and system architecture.