### PR TITLE
Add Support to Specify Go Version to Set Up

### DIFF
--- a/cmake/SetupGo.cmake
+++ b/cmake/SetupGo.cmake
@@ -3,14 +3,23 @@
 
 include_guard(GLOBAL)
 
-# Sets up the latest version of Go within this project.
+# Sets up a specific version of Go within this project.
 #
-# This function downloads the latest version of the Go build from the remote server, extracts it,
+# This function downloads a specific version of the Go build from the remote server, extracts it,
 # and makes it available in the project.
 #
+# If the version is not specified, it will download the latest version of the Go build.
+#
 # This function sets the `GO_EXECUTABLE` variable to the location of the Go executable.
+#
+# Optional arguments:
+#   - VERSION: The version of Go to set up.
 function(setup_go)
-  set(VERSION 1.22.2)
+  cmake_parse_arguments(ARG "" "VERSION" "" ${ARGN})
+
+  if(NOT DEFINED ARG_VERSION)
+    set(ARG_VERSION 1.22.2)
+  endif()
 
   if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
     set(OS darwin)
@@ -37,7 +46,7 @@ function(setup_go)
     set(PACKAGE_EXT .tar.gz)
   endif()
 
-  set(GO_BUILD go${VERSION}.${OS}-${ARCH})
+  set(GO_BUILD go${ARG_VERSION}.${OS}-${ARCH})
   set(GO_PACKAGE ${GO_BUILD}${PACKAGE_EXT})
   set(GO_EXECUTABLE ${CMAKE_BINARY_DIR}/_deps/${GO_BUILD}/go/bin/go${EXECUTABLE_EXT})
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,4 +16,5 @@ endfunction()
 add_cmake_test(
   cmake/SetupGoTest.cmake
   "Set up the latest version of Go"
+  "Set up a specific version of Go"
 )

--- a/test/cmake/SetupGoTest.cmake
+++ b/test/cmake/SetupGoTest.cmake
@@ -7,10 +7,8 @@ set(TEST_COUNT 0)
 
 include(SetupGo)
 
-if("Set up the latest version of Go" MATCHES ${TEST_MATCHES})
-  math(EXPR TEST_COUNT "${TEST_COUNT} + 1")
-
-  setup_go()
+function(assert_go_executable)
+  cmake_parse_arguments(ARG "" "VERSION" "" ${ARGN})
 
   if(NOT DEFINED GO_EXECUTABLE)
     message(FATAL_ERROR "The GO_EXECUTABLE variable should be defined")
@@ -27,9 +25,16 @@ if("Set up the latest version of Go" MATCHES ${TEST_MATCHES})
   )
   if(NOT RES EQUAL 0)
     message(FATAL_ERROR "It should not fail to execute the Go executable")
-  elseif(NOT OUT MATCHES "^go version go1.22.2")
-    message(FATAL_ERROR "It should execute the version 1.22.1 of Go")
+  elseif(DEFINED ARG_VERSION AND NOT OUT MATCHES "^go version go${ARG_VERSION}")
+    message(FATAL_ERROR "It should execute the version ${ARG_VERSION} of Go")
   endif()
+endfunction()
+
+if("Set up the latest version of Go" MATCHES ${TEST_MATCHES})
+  math(EXPR TEST_COUNT "${TEST_COUNT} + 1")
+
+  setup_go()
+  assert_go_executable(VERSION 1.22.2)
 endif()
 
 if(TEST_COUNT LESS_EQUAL 0)

--- a/test/cmake/SetupGoTest.cmake
+++ b/test/cmake/SetupGoTest.cmake
@@ -37,6 +37,13 @@ if("Set up the latest version of Go" MATCHES ${TEST_MATCHES})
   assert_go_executable(VERSION 1.22.2)
 endif()
 
+if("Set up a specific version of Go" MATCHES ${TEST_MATCHES})
+  math(EXPR TEST_COUNT "${TEST_COUNT} + 1")
+
+  setup_go(VERSION 1.21.9)
+  assert_go_executable(VERSION 1.21.9)
+endif()
+
 if(TEST_COUNT LESS_EQUAL 0)
   message(FATAL_ERROR "Nothing to test with: ${TEST_MATCHES}")
 endif()

--- a/test/cmake/SetupGoTest.cmake
+++ b/test/cmake/SetupGoTest.cmake
@@ -23,9 +23,12 @@ if("Set up the latest version of Go" MATCHES ${TEST_MATCHES})
   execute_process(
     COMMAND ${GO_EXECUTABLE} version
     RESULT_VARIABLE RES
+    OUTPUT_VARIABLE OUT
   )
   if(NOT RES EQUAL 0)
     message(FATAL_ERROR "It should not fail to execute the Go executable")
+  elseif(NOT OUT MATCHES "^go version go1.22.2")
+    message(FATAL_ERROR "It should execute the version 1.22.1 of Go")
   endif()
 endif()
 


### PR DESCRIPTION
This pull request resolves #20 by introducing the following changes:
- Adds a `VERSION` argument to the `setup_go` function for specifying the Go version to set up.
- Adds support for asserting the Go version in the `SetupGoTest.cmake`.
- Adds testing in the `SetupGoTest.cmake` that tests setting up a specific version of Go by passing the `VERSION` argument to the `setup_go` function.