### PR TITLE
Add Status Message in CMake Function

### DIFF
--- a/cmake/SetupGo.cmake
+++ b/cmake/SetupGo.cmake
@@ -52,10 +52,12 @@ function(setup_go)
 
   if(NOT EXISTS ${GO_EXECUTABLE})
     # Download the Go build.
+    message(STATUS "SetupGo: Downloading https://go.dev/dl/${GO_PACKAGE}...")
     file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/_deps)
     file(DOWNLOAD https://go.dev/dl/${GO_PACKAGE} ${CMAKE_BINARY_DIR}/_deps/${GO_PACKAGE})
 
     # Extract the Go build.
+    message(STATUS "SetupGo: Extracting ${CMAKE_BINARY_DIR}/_deps/${GO_PACKAGE}...")
     file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/_deps/${GO_BUILD})
     execute_process(
       COMMAND tar -xf ${CMAKE_BINARY_DIR}/_deps/${GO_PACKAGE} -C ${CMAKE_BINARY_DIR}/_deps/${GO_BUILD}


### PR DESCRIPTION
This pull request resolves #28 by adding status messages in the `setup_go` function to indicate the current step for setting up Go.