### PR TITLE
Specify CMake Minimum Version in Test Modules

### DIFF
--- a/test/cmake/SetupGoTest.cmake
+++ b/test/cmake/SetupGoTest.cmake
@@ -1,3 +1,5 @@
+cmake_minimum_required(VERSION 3.5)
+
 include(SetupGo)
 
 function(assert_go_executable)


### PR DESCRIPTION
This pull request resolves #47 by simply specifying the CMake minimum required version in the test modules.