### PR TITLE
Improve Function Arguments Handling

### DIFF
--- a/cmake/SetupGo.cmake
+++ b/cmake/SetupGo.cmake
@@ -15,7 +15,7 @@ include_guard(GLOBAL)
 # Optional arguments:
 #   - VERSION: The version of Go to set up.
 function(setup_go)
-  cmake_parse_arguments(ARG "" "VERSION" "" ${ARGN})
+  cmake_parse_arguments(PARSE_ARGV 0 ARG "" "VERSION" "")
 
   if(NOT DEFINED ARG_VERSION)
     set(ARG_VERSION 1.22.2)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,13 +1,14 @@
 function(add_cmake_test FILE)
-  foreach(NAME ${ARGN})
+  math(EXPR STOP "${ARGC} - 1")
+  foreach(I RANGE 1 "${STOP}")
     add_test(
-      NAME "${NAME}"
+      NAME "${ARGV${I}}"
       COMMAND "${CMAKE_COMMAND}"
         -D CMAKE_SYSTEM_NAME=${CMAKE_SYSTEM_NAME}
         -D CMAKE_SYSTEM_PROCESSOR=${CMAKE_SYSTEM_PROCESSOR}
         -D CMAKE_MODULE_PATH=${CMAKE_MODULE_PATH}
         -D CMAKE_BINARY_DIR=${CMAKE_CURRENT_SOURCE_DIR}/build
-        -D TEST_COMMAND=${NAME}
+        -D "TEST_COMMAND=${ARGV${I}}"
         -P ${CMAKE_CURRENT_SOURCE_DIR}/${FILE}
     )
   endforeach()


### PR DESCRIPTION
This pull request resolves #55 by introducing the following changes:
- Utilizes the `ARGC` and `ARGV<INDEX>` variables in the `add_cmake_test` function.
- Utilizes the `cmake_parse_arguments(PARSE_ARGV)` function in the `setup_go` function.