### PR TITLE
Add Option to Enable Test Targets

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Configure Project
         uses: threeal/cmake-action@v1.3.0
         with:
-          options: BUILD_TESTING=ON
+          options: SETUP_GO_ENABLE_TESTS=ON
 
       - name: Test Project
         uses: threeal/ctest-action@v1.0.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,12 +8,13 @@ project(
   LANGUAGES NONE
 )
 
+option(SETUP_GO_ENABLE_TESTS "Enable test targets.")
 option(
   SETUP_GO_ENABLE_INSTALL "Enable install targets." "${PROJECT_IS_TOP_LEVEL}")
 
 include(cmake/SetupGo.cmake)
 
-if(PROJECT_IS_TOP_LEVEL AND BUILD_TESTING)
+if(SETUP_GO_ENABLE_TESTS)
   enable_testing()
   add_subdirectory(test)
 endif()


### PR DESCRIPTION
This pull request resolves #65 by adding a `SETUP_GO_ENABLE_TESTS` option to enable test targets in the project, replacing the `BUILD_TESTING` variable.