### PR TITLE
Organize Tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,3 +25,4 @@ jobs:
         uses: threeal/ctest-action@v1.1.0
         with:
           build-config: debug
+          verbose: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,11 +17,13 @@ include(cmake/SetupGo.cmake)
 if(SETUP_GO_ENABLE_TESTS)
   enable_testing()
 
-  add_test(
-    NAME test/setup_go.cmake
-    COMMAND "${CMAKE_COMMAND}"
-      -D CMAKE_BINARY_DIR=${CMAKE_CURRENT_SOURCE_DIR}/build
-      -P ${CMAKE_CURRENT_SOURCE_DIR}/test/setup_go.cmake)
+  file(
+    DOWNLOAD https://github.com/threeal/assertion-cmake/releases/download/v1.0.0/Assertion.cmake
+      ${CMAKE_BINARY_DIR}/Assertion.cmake
+    EXPECTED_MD5 1d8ec589d6cc15772581bf77eb3873ff)
+  include(${CMAKE_BINARY_DIR}/Assertion.cmake)
+
+  assertion_add_test(test/setup_go.cmake)
 endif()
 
 if(SETUP_GO_ENABLE_INSTALL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,12 @@ include(cmake/SetupGo.cmake)
 
 if(SETUP_GO_ENABLE_TESTS)
   enable_testing()
-  add_subdirectory(test)
+
+  add_test(
+    NAME test/setup_go.cmake
+    COMMAND "${CMAKE_COMMAND}"
+      -D CMAKE_BINARY_DIR=${CMAKE_CURRENT_SOURCE_DIR}/build
+      -P ${CMAKE_CURRENT_SOURCE_DIR}/test/setup_go.cmake)
 endif()
 
 if(SETUP_GO_ENABLE_INSTALL)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,0 @@
-add_test(
-  NAME cmake/SetupGoTest.cmake
-  COMMAND "${CMAKE_COMMAND}"
-    -D CMAKE_BINARY_DIR=${CMAKE_CURRENT_SOURCE_DIR}/build
-    -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/SetupGoTest.cmake)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,18 +1,5 @@
-function(add_cmake_test FILE)
-  math(EXPR STOP "${ARGC} - 1")
-  foreach(I RANGE 1 "${STOP}")
-    add_test(
-      NAME "${ARGV${I}}"
-      COMMAND "${CMAKE_COMMAND}"
-        -D CMAKE_BINARY_DIR=${CMAKE_CURRENT_SOURCE_DIR}/build
-        -D "TEST_COMMAND=${ARGV${I}}"
-        -P ${CMAKE_CURRENT_SOURCE_DIR}/${FILE}
-    )
-  endforeach()
-endfunction()
-
-add_cmake_test(
-  cmake/SetupGoTest.cmake
-  "Set up the latest version of Go"
-  "Set up a specific version of Go"
-)
+add_test(
+  NAME cmake/SetupGoTest.cmake
+  COMMAND "${CMAKE_COMMAND}"
+    -D CMAKE_BINARY_DIR=${CMAKE_CURRENT_SOURCE_DIR}/build
+    -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/SetupGoTest.cmake)

--- a/test/cmake/SetupGoTest.cmake
+++ b/test/cmake/SetupGoTest.cmake
@@ -8,25 +8,26 @@ include(${CMAKE_BINARY_DIR}/Assertion.cmake)
 
 find_package(SetupGo REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../../cmake)
 
-# Asserts whether a Go executable exists with the specified version.
-#
-# Arguments:
-#   - VERSION: The expected version of the Go executable.
-function(assert_go_executable VERSION)
+section("it should set up the latest version of Go")
+  setup_go()
+
   assert(DEFINED GO_EXECUTABLE)
   assert(EXISTS "${GO_EXECUTABLE}")
+  assert(IS_EXECUTABLE "${GO_EXECUTABLE}")
 
   assert_execute_process(
     COMMAND "${GO_EXECUTABLE}" version
-    OUTPUT "^go version go${VERSION}")
-endfunction()
-
-section("it should set up the latest version of Go")
-  setup_go()
-  assert_go_executable(1.22.5)
+    OUTPUT "^go version go1.22.5")
 endsection()
 
 section("it should set up a specific version of Go")
   setup_go(VERSION 1.21.9)
-  assert_go_executable(1.21.9)
+
+  assert(DEFINED GO_EXECUTABLE)
+  assert(EXISTS "${GO_EXECUTABLE}")
+  assert(IS_EXECUTABLE "${GO_EXECUTABLE}")
+
+  assert_execute_process(
+    COMMAND "${GO_EXECUTABLE}" version
+    OUTPUT "^go version go1.21.9")
 endsection()

--- a/test/cmake/SetupGoTest.cmake
+++ b/test/cmake/SetupGoTest.cmake
@@ -21,14 +21,12 @@ function(assert_go_executable VERSION)
     OUTPUT "^go version go${VERSION}")
 endfunction()
 
-function("Set up the latest version of Go")
+section("it should set up the latest version of Go")
   setup_go()
   assert_go_executable(1.22.5)
-endfunction()
+endsection()
 
-function("Set up a specific version of Go")
+section("it should set up a specific version of Go")
   setup_go(VERSION 1.21.9)
   assert_go_executable(1.21.9)
-endfunction()
-
-cmake_language(CALL "${TEST_COMMAND}")
+endsection()

--- a/test/setup_go.cmake
+++ b/test/setup_go.cmake
@@ -1,11 +1,3 @@
-cmake_minimum_required(VERSION 3.5)
-
-file(
-  DOWNLOAD https://github.com/threeal/assertion-cmake/releases/download/v1.0.0/Assertion.cmake
-    ${CMAKE_BINARY_DIR}/Assertion.cmake
-  EXPECTED_MD5 1d8ec589d6cc15772581bf77eb3873ff)
-include(${CMAKE_BINARY_DIR}/Assertion.cmake)
-
 find_package(SetupGo REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../cmake)
 
 section("it should set up the latest version of Go")

--- a/test/setup_go.cmake
+++ b/test/setup_go.cmake
@@ -6,7 +6,7 @@ file(
   EXPECTED_MD5 1d8ec589d6cc15772581bf77eb3873ff)
 include(${CMAKE_BINARY_DIR}/Assertion.cmake)
 
-find_package(SetupGo REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../../cmake)
+find_package(SetupGo REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../cmake)
 
 section("it should set up the latest version of Go")
   setup_go()


### PR DESCRIPTION
This pull request resolves #70 by introducing the following changes:
- Run test cases sequentially in the same module.
- Simplify setup Go test assertions without the need for the `assert_go_executable` function.
- Utilize the `assertion_add_test` function to declare CMake tests.
- Run tests verbosely in the workflow.