### PR TITLE
Bump Latest Go to Version 1.22.5

### DIFF
--- a/cmake/SetupGo.cmake
+++ b/cmake/SetupGo.cmake
@@ -18,7 +18,7 @@ function(setup_go)
   cmake_parse_arguments(PARSE_ARGV 0 ARG "" "VERSION" "")
 
   if(NOT DEFINED ARG_VERSION)
-    set(ARG_VERSION 1.22.2)
+    set(ARG_VERSION 1.22.5)
   endif()
 
   if(CMAKE_HOST_SYSTEM_NAME STREQUAL Darwin)

--- a/test/cmake/SetupGoTest.cmake
+++ b/test/cmake/SetupGoTest.cmake
@@ -23,7 +23,7 @@ endfunction()
 
 function("Set up the latest version of Go")
   setup_go()
-  assert_go_executable(1.22.2)
+  assert_go_executable(1.22.5)
 endfunction()
 
 function("Set up a specific version of Go")


### PR DESCRIPTION
This pull request simply bumps the latest Go version to [1.22.5](https://go.dev/doc/devel/release#go1.22.minor).