### PR TITLE
Specify Runner OS Version in Workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   build-project:
     name: Build Project
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.7

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,11 +7,11 @@ on:
 jobs:
   test-project:
     name: Test Project
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [macos, ubuntu, windows]
+        os: [ubuntu-22.04, macos-14, windows-2022]
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.7


### PR DESCRIPTION
This pull request resolves #81 by manually specifying the runner OS version to be used in workflows, replacing the default latest version.