### PR TITLE
Bump Assertion.cmake to Version 2.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,12 +18,13 @@ if(SETUP_GO_ENABLE_TESTS)
   enable_testing()
 
   file(
-    DOWNLOAD https://github.com/threeal/assertion-cmake/releases/download/v1.0.0/Assertion.cmake
-      ${CMAKE_BINARY_DIR}/Assertion.cmake
-    EXPECTED_MD5 1d8ec589d6cc15772581bf77eb3873ff)
-  include(${CMAKE_BINARY_DIR}/Assertion.cmake)
+    DOWNLOAD https://github.com/threeal/assertion-cmake/releases/download/v2.0.0/Assertion.cmake
+      ${CMAKE_BINARY_DIR}/cmake/Assertion.cmake
+    EXPECTED_MD5 5ebe475aee6fc5660633152f815ce9f6)
+  include(${CMAKE_BINARY_DIR}/cmake/Assertion.cmake)
 
-  assertion_add_test(test/setup_go.cmake)
+  add_cmake_script_test(test/setup_go.cmake
+    DEFINITIONS CMAKE_MODULE_PATH=${CMAKE_BINARY_DIR}/cmake)
 endif()
 
 if(SETUP_GO_ENABLE_INSTALL)

--- a/test/setup_go.cmake
+++ b/test/setup_go.cmake
@@ -1,3 +1,6 @@
+cmake_minimum_required(VERSION 3.21)
+
+include(Assertion)
 find_package(SetupGo REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../cmake)
 
 section("it should set up the latest version of Go")
@@ -7,9 +10,8 @@ section("it should set up the latest version of Go")
   assert(EXISTS "${GO_EXECUTABLE}")
   assert(IS_EXECUTABLE "${GO_EXECUTABLE}")
 
-  assert_execute_process(
-    COMMAND "${GO_EXECUTABLE}" version
-    OUTPUT "^go version go1.22.5")
+  assert_execute_process("${GO_EXECUTABLE}" version
+    EXPECT_OUTPUT "^go version go1.22.5")
 endsection()
 
 section("it should set up a specific version of Go")
@@ -19,7 +21,6 @@ section("it should set up a specific version of Go")
   assert(EXISTS "${GO_EXECUTABLE}")
   assert(IS_EXECUTABLE "${GO_EXECUTABLE}")
 
-  assert_execute_process(
-    COMMAND "${GO_EXECUTABLE}" version
-    OUTPUT "^go version go1.21.9")
+  assert_execute_process("${GO_EXECUTABLE}" version
+    EXPECT_OUTPUT "^go version go1.21.9")
 endsection()


### PR DESCRIPTION
This pull request updates the [Assertion.cmake](https://github.com/threeal/assertion-cmake/) project used by this project to version [2.0.0](https://github.com/threeal/assertion-cmake/releases/tag/v2.0.0). The change also updates the test declarations accordingly, following the changes implemented in the new version.