### PR TITLE
Follow CMake Starter Version 2.2.0 Configuration and Style

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,7 +9,7 @@ jobs:
     name: Build Project
     runs-on: ubuntu-22.04
     steps:
-      - name: Checkout
+      - name: Checkout Project
         uses: actions/checkout@v4.2.2
 
       - name: Configure Project
@@ -18,7 +18,7 @@ jobs:
       - name: Package Project
         run: cpack --preset default
 
-      - name: Upload Project as Artifact
+      - name: Upload Project
         uses: actions/upload-artifact@v4.4.3
         with:
           path: build/SetupGo.tar.gz

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04, macos-14, windows-2022]
     steps:
-      - name: Checkout
+      - name: Checkout Project
         uses: actions/checkout@v4.2.2
 
       - name: Configure Project

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.21)
 
 project(
   SetupGo
-  VERSION 1.0.0
+  VERSION 1.1.0
   DESCRIPTION "Set up a specific version of Go from a CMake project"
   HOMEPAGE_URL https://github.com/threeal/setup-go-cmake
   LANGUAGES NONE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,20 +14,19 @@ option(
 
 list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
+# Prefer system packages over the find modules provided by this project.
+if(NOT DEFINED CMAKE_FIND_PACKAGE_PREFER_CONFIG)
+  set(CMAKE_FIND_PACKAGE_PREFER_CONFIG TRUE)
+endif()
+
 # Include the main module.
 include(SetupGo)
 
 if(SETUP_GO_ENABLE_TESTS)
   enable_testing()
 
-  file(
-    DOWNLOAD https://github.com/threeal/assertion-cmake/releases/download/v2.0.0/Assertion.cmake
-      ${CMAKE_BINARY_DIR}/cmake/Assertion.cmake
-    EXPECTED_MD5 5ebe475aee6fc5660633152f815ce9f6)
-  include(${CMAKE_BINARY_DIR}/cmake/Assertion.cmake)
-
-  add_cmake_script_test(test/setup_go.cmake
-    DEFINITIONS CMAKE_MODULE_PATH=${CMAKE_BINARY_DIR}/cmake)
+  find_package(Assertion 2.0.0 REQUIRED)
+  add_cmake_script_test(test/setup_go.cmake DEFINITIONS CMAKE_MODULE_PATH)
 endif()
 
 if(SETUP_GO_ENABLE_INSTALL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,19 +28,18 @@ if(SETUP_GO_ENABLE_TESTS)
 endif()
 
 if(SETUP_GO_ENABLE_INSTALL)
+  file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/cmake/SetupGoConfig.cmake
+    "include(\${CMAKE_CURRENT_LIST_DIR}/SetupGo.cmake)\n")
+
   include(CMakePackageConfigHelpers)
-  write_basic_package_version_file(
-    SetupGoConfigVersion.cmake
-    COMPATIBILITY SameMajorVersion
-  )
+  write_basic_package_version_file(cmake/SetupGoConfigVersion.cmake
+    COMPATIBILITY SameMajorVersion ARCH_INDEPENDENT)
 
   install(
-    FILES
-      cmake/SetupGo.cmake
-      cmake/SetupGoConfig.cmake
-      ${CMAKE_CURRENT_BINARY_DIR}/SetupGoConfigVersion.cmake
-    DESTINATION lib/cmake/SetupGo
-  )
+    FILES cmake/SetupGo.cmake
+      ${CMAKE_CURRENT_BINARY_DIR}/cmake/SetupGoConfig.cmake
+      ${CMAKE_CURRENT_BINARY_DIR}/cmake/SetupGoConfigVersion.cmake
+    DESTINATION lib/cmake/SetupGo)
 
   set(CPACK_PACKAGE_FILE_NAME "${PROJECT_NAME}")
   include(CPack)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,12 +5,11 @@ project(
   VERSION 1.0.0
   DESCRIPTION "Set up a specific version of Go from a CMake project"
   HOMEPAGE_URL https://github.com/threeal/setup-go-cmake
-  LANGUAGES NONE
-)
+  LANGUAGES NONE)
 
 option(SETUP_GO_ENABLE_TESTS "Enable test targets.")
-option(
-  SETUP_GO_ENABLE_INSTALL "Enable install targets." "${PROJECT_IS_TOP_LEVEL}")
+option(SETUP_GO_ENABLE_INSTALL
+  "Enable install targets." "${PROJECT_IS_TOP_LEVEL}")
 
 list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,10 @@ option(SETUP_GO_ENABLE_TESTS "Enable test targets.")
 option(
   SETUP_GO_ENABLE_INSTALL "Enable install targets." "${PROJECT_IS_TOP_LEVEL}")
 
-include(cmake/SetupGo.cmake)
+list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+
+# Include the main module.
+include(SetupGo)
 
 if(SETUP_GO_ENABLE_TESTS)
   enable_testing()
@@ -29,7 +32,8 @@ endif()
 
 if(SETUP_GO_ENABLE_INSTALL)
   file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/cmake/SetupGoConfig.cmake
-    "include(\${CMAKE_CURRENT_LIST_DIR}/SetupGo.cmake)\n")
+    "list(PREPEND CMAKE_MODULE_PATH \${CMAKE_CURRENT_LIST_DIR})\n"
+    "include(SetupGo)\n")
 
   include(CMakePackageConfigHelpers)
   write_basic_package_version_file(cmake/SetupGoConfigVersion.cmake

--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ This module can be integrated into a CMake project in the following ways:
 - Use [`file(DOWNLOAD)`](https://cmake.org/cmake/help/latest/command/file.html#download) to automatically download the `SetupGo.cmake` file:
   ```cmake
   file(
-    DOWNLOAD https://github.com/threeal/setup-go-cmake/releases/download/v1.0.0/SetupGo.cmake
+    DOWNLOAD https://github.com/threeal/setup-go-cmake/releases/download/v1.1.0/SetupGo.cmake
       ${CMAKE_BINARY_DIR}/SetupGo.cmake)
   include(${CMAKE_BINARY_DIR}/SetupGo.cmake)
   ```
 - Use [CPM.cmake](https://github.com/cpm-cmake/CPM.cmake) to add this package to the CMake project:
   ```cmake
-  cpmaddpackage(gh:threeal/setup-go-cmake@1.0.0)
+  cpmaddpackage(gh:threeal/setup-go-cmake@1.1.0)
   ```
 
 ## Example Usages

--- a/cmake/FindAssertion.cmake
+++ b/cmake/FindAssertion.cmake
@@ -1,0 +1,9 @@
+set(DOWNLOAD_URL https://github.com/threeal/assertion-cmake/releases/download)
+file(DOWNLOAD ${DOWNLOAD_URL}/v${Assertion_FIND_VERSION}/Assertion.tar.gz
+  ${CMAKE_BINARY_DIR}/_deps/Assertion.tar.gz)
+
+file(ARCHIVE_EXTRACT INPUT ${CMAKE_BINARY_DIR}/_deps/Assertion.tar.gz
+  DESTINATION ${CMAKE_BINARY_DIR}/_deps)
+
+include(CMakeFindDependencyMacro)
+find_dependency(Assertion CONFIG PATHS ${CMAKE_BINARY_DIR}/_deps)

--- a/cmake/SetupGo.cmake
+++ b/cmake/SetupGo.cmake
@@ -20,8 +20,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-include_guard(GLOBAL)
-
 # Sets up a specific version of Go within this project.
 #
 # This function downloads a specific version of the Go build from the remote server, extracts it,

--- a/cmake/SetupGo.cmake
+++ b/cmake/SetupGo.cmake
@@ -97,8 +97,7 @@ function(setup_go)
     file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/_deps/${GO_BUILD})
     execute_process(
       COMMAND "${TAR_EXECUTABLE}" -xf ${CMAKE_BINARY_DIR}/_deps/${GO_PACKAGE} -C ${CMAKE_BINARY_DIR}/_deps/${GO_BUILD}
-      RESULT_VARIABLE RES
-    )
+      RESULT_VARIABLE RES)
     if(NOT RES EQUAL 0)
       message(FATAL_ERROR "Failed to extract '${CMAKE_BINARY_DIR}/_deps/${GO_PACKAGE}' to '${CMAKE_BINARY_DIR}/_deps/${GO_BUILD}' (${RES})")
     endif()

--- a/cmake/SetupGoConfig.cmake
+++ b/cmake/SetupGoConfig.cmake
@@ -1,1 +1,0 @@
-include(${CMAKE_CURRENT_LIST_DIR}/SetupGo.cmake)

--- a/test/setup_go.cmake
+++ b/test/setup_go.cmake
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.21)
 
 include(Assertion)
-find_package(SetupGo REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/../cmake/SetupGo.cmake)
 
 section("it should set up the latest version of Go")
   setup_go()


### PR DESCRIPTION
This pull request resolves #98 by implementing the [CMake Starter version 2.2.0](https://github.com/threeal/cmake-starter/tree/v2.2.0) configuration and style. Refer to each commit for more details about each implemented change.