### PR TITLE
Remove Upload Project Step in CI Workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,10 +17,3 @@ jobs:
 
       - name: Package Project
         run: cpack --preset default
-
-      - name: Upload Project
-        uses: actions/upload-artifact@v4.6.2
-        with:
-          path: build/SetupGo.tar.gz
-          if-no-files-found: error
-          overwrite: true


### PR DESCRIPTION
This pull request resolves #108 by removing the step that uploads the project as an artifact from the CI workflows.